### PR TITLE
Added list of valid Bootstrap components

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Also, an ignore option. (cannot be used at the same time as the only option)
   }
 }
 ```
+A full list of components that can be listed under ignore or only are shown below. 
+```javascript
+['alert', 'button',  'carousel', 'collapse', 'dropdown', 'modal', 'popover', 'scrollspy', 'tab', 'tooltip']
+```
+
 Once you have the above setup in your add the code below to include the custom build in your bundle.
 ```
 import 'bootstrap.native';


### PR DESCRIPTION
Currently it is not clear what are valid values for only or ignore. Adding a list of components will make it easier to initially use the bootstrap.native-loader.