### PR TITLE
adapt for unified build script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,10 @@
-const bsn3 = require('bootstrap.native/build-module.js')
-let bsn = require('bootstrap.native/build-module-v4.js')
+const bsn = require('bootstrap.native/lib/build-module.js')
 const { getOptions } = require('loader-utils')
 
 module.exports = function () {
   this.cacheable = true
   const callback = this.async()
   const options = getOptions(this) || {}
-
-  if (options.bsVersion === 3) {
-    bsn = bsn3
-  }
 
   bsn(options).then((source) => {
     callback(null, source)

--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = function () {
   this.cacheable = true
   const callback = this.async()
   const options = getOptions(this) || {}
+  options.bs_version = options.bs_version || 4;
 
   bsn(options).then((source) => {
     callback(null, source)


### PR DESCRIPTION
Hi :)

as latest bsn uses a unified build script now, we have to adapt our loader.
It builds default for bootstrap 3, so you have so specify `bs_version: '4'` in webpack for bootrap 4

Cheers
midzer
