### PR TITLE
Support for bootstrap.native 2.0.26

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ There's also an only option. (cannot be used at the same time as the ignore opti
   use: {
     loader: 'bootstrap.native-loader',
     options: {
+      bs_version: 4,
       only: ['modal', 'dropdown']
     }
   }
@@ -37,6 +38,7 @@ Also, an ignore option. (cannot be used at the same time as the only option)
   use: {
     loader: 'bootstrap.native-loader',
     options: {
+      bs_version: 4,
       ignore: ['carousel', 'button']
     }
   }

--- a/index.js
+++ b/index.js
@@ -1,15 +1,10 @@
-const bsn3 = require('bootstrap.native/build-module.js')
-let bsn = require('bootstrap.native/build-module-v4.js')
+const bsn = require('bootstrap.native/lib/build-module.js')
 const { getOptions } = require('loader-utils')
 
 module.exports = function () {
   this.cacheable = true
   const callback = this.async()
   const options = getOptions(this) || {}
-
-  if (options.bsVersion === 3) {
-    bsn = bsn3
-  }
 
   bsn(options).then((source) => {
     callback(null, source)


### PR DESCRIPTION
The build-module.js script has been moved to the `./lib` directory and takes a new parameter `bs_version`.